### PR TITLE
fix conflicting tableId

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ ZongJi.prototype._fetchTableInfo = function(tableMapEvent, next) {
 
     self.tableMap[tableMapEvent.tableId] = {
       columnSchemas: rows,
-      parentSchema: tableMapEvent.schemaName,
+      schemaName: tableMapEvent.schemaName,
       tableName: tableMapEvent.tableName
     };
 

--- a/lib/binlog_event.js
+++ b/lib/binlog_event.js
@@ -155,6 +155,12 @@ function TableMap(parser, options, zongji) {
   var tableNameLength = parser.parseUnsignedNumber(1);
   this.tableName = parser.parseString(tableNameLength);
 
+  // handle conflicting tableId
+  if (this.tableMap[this.tableId] && (this.tableMap[this.tableId].tableName != this.tableName || this.tableMap[this.tableId].schemaName != this.schemaName)) {
+    //console.debug(`Conflicting tableId: ${this.tableId}; ${this.tableMap[this.tableId].schemaName}.${this.tableMap[this.tableId].tableName} >> ${this.schemaName}.${this.tableName}`);
+    this.tableMap[this.tableId] = null;
+  }
+
   if (zongji._skipSchema(this.schemaName, this.tableName)) {
     // This event has been filtered out because of its database/table
     parser._offset = parser._packetEnd;

--- a/lib/common.js
+++ b/lib/common.js
@@ -586,7 +586,7 @@ exports.readMysqlValue = function(
         new Error('Unsupported type "' + column.type +
           '" on column "' + column.name +
           '" of the table "' + tableMap.tableName +
-          '" in the database "' + tableMap.parentSchema + '"'));
+          '" in the database "' + tableMap.schemaName + '"'));
   }
   return result;
 };

--- a/test/events.js
+++ b/test/events.js
@@ -10,7 +10,7 @@ var conn = process.testZongJi || {};
 var checkTableMatches = function(tableName) {
   return function(test, event) {
     var tableDetails = event.tableMap[event.tableId];
-    test.strictEqual(tableDetails.parentSchema, settings.database);
+    test.strictEqual(tableDetails.schemaName, settings.database);
     test.strictEqual(tableDetails.tableName, tableName);
   };
 };

--- a/test/types.js
+++ b/test/types.js
@@ -69,7 +69,7 @@ var defineTypeTest = function(name, fields, testRows, customTest, minVersion) {
           _type: 'WriteRows',
           _checkTableMap: function(test, event) {
             var tableDetails = event.tableMap[event.tableId];
-            test.strictEqual(tableDetails.parentSchema, settings.database);
+            test.strictEqual(tableDetails.schemaName, settings.database);
             test.strictEqual(tableDetails.tableName, testTable);
           }
         };


### PR DESCRIPTION
Recently I have been experiencing some weird issues (packets out of order, RangeError: Index out of range). After a long time of debugging i have noticed that i had conflicting tableId, which causes zongji to crash. I made some changes to get such cases detected and handled. 